### PR TITLE
chore(deps):rebase cryptography fork, bump version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 2.7.9
+    version: 2.7.10
 
 dependencies:
   override:

--- a/setup.py
+++ b/setup.py
@@ -41,16 +41,16 @@ else:
 
 
 INSTALL_REQUIRES = [
-    'cryptography==0.9.1f',
+    'cryptography==1.0.1f',
     'requests>=2.7.0',
     'six>=1.9.0',
 ]
 
 
-# cryptography==0.9.1f is not on pypi, so provide a link
+# cryptography==1.0.1f is not on pypi, so provide a link
 DEPENDENCY_LINKS = [
     ('https://github.com/samstav/cryptography'
-     '/tarball/rsa-bypass-hash-on-signer#egg=cryptography-0.9.1f'),
+     '/tarball/rsa-bypass-hash-on-signer#egg=cryptography-1.0.1f'),
 ]
 
 


### PR DESCRIPTION
Rebased https://github.com/samstav/cryptography/tree/rsa-bypass-hash-on-signer

https://cryptography.io/en/latest/changelog/#id1
https://github.com/pyca/cryptography/releases/tag/1.0.1
