### PR TITLE
Ensure private_key is a bytes object if str passed

### DIFF
--- a/requests_chef/mixlib_auth.py
+++ b/requests_chef/mixlib_auth.py
@@ -164,6 +164,9 @@ class RSAKey(object):
         if os.path.isfile(maybe_path):
             with open(maybe_path, 'rb') as pkf:
                 private_key = pkf.read()
+        if not isinstance(private_key, six.binary_type):
+            private_key = private_key.encode('utf-8')
+
         pkey = serialization.load_pem_private_key(
             private_key,
             password=password,

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ skipsdist = True
 [testenv]
 # This is the default setup. All other environments will inherit these settings
 usedevelop = True
-install_command = pip install --verbose --pre --download-cache ~/.pip/cache --exists-action=w {opts} {packages}
+install_command = pip install --verbose --pre --exists-action=w {opts} {packages}
 basepython = python
 pyflake_codes = F401,F402,F403,F404,F811,F812,F821,F822,F823,F831,F841
 


### PR DESCRIPTION
If `load_pem` is called with a string instead of a file, it should ensure that the string gets encoded before passing to `cryptography` - otherwise it results in this error:

```
initializer for ctype 'char[]' must be a bytes or list or tuple, not str
```
