### PR TITLE
Work in progress: Use asymmetric.utils.Prehashed from cryptography 1.6

### DIFF
--- a/requests_chef/mixlib_auth.py
+++ b/requests_chef/mixlib_auth.py
@@ -30,9 +30,11 @@ import requests
 import six
 
 from cryptography.hazmat import backends as crypto_backends
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import utils
 
 
 def digester(data):
@@ -181,12 +183,15 @@ class RSAKey(object):
 
         The signed data will be Base64 encoded if b64 is True.
         """
-        padder = padding.PKCS1v15()
-        signer = self.private_key.signer(padder, None)
         if not isinstance(data, six.binary_type):
             data = data.encode('utf_8')
-        signer.update(data)
-        signed = signer.finalize()
+
+        signature = self.private_key.sign(
+            hashlib.sha1(data).digest(),
+            padding.PKCS1v15(),
+            utils.Prehashed(hashes.SHA1())
+        )
         if b64:
-            signed = base64.b64encode(signed)
+            signed = base64.b64encode(signature)
+
         return signed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/samstav/cryptography.git@rsa-bypass-hash-on-signer#egg=cryptography==1.3.1f
+cryptography>=1.6
 requests==2.12.3
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -42,16 +42,9 @@ else:
 
 
 INSTALL_REQUIRES = [
-    'cryptography==1.3.1f',
+    'cryptography>=1.6',
     'requests>=2.7.0',
     'six>=1.9.0',
-]
-
-
-# cryptography==1.3.1f is not on pypi, so provide a link
-DEPENDENCY_LINKS = [
-    ('https://github.com/samstav/cryptography'
-     '/tarball/rsa-bypass-hash-on-signer#egg=cryptography-1.3.1f'),
 ]
 
 
@@ -90,7 +83,6 @@ package_attributes = {
     'name': about['__title__'],
     'description': about['__summary__'],
     'long_description': LONG_DESCRIPTION,
-    'dependency_links': DEPENDENCY_LINKS,
     'keywords': ' '.join(about['__keywords__']),
     'version': about['__version__'],
     'tests_require': TESTS_REQUIRE,


### PR DESCRIPTION
https://cryptography.io/en/latest/hazmat/primitives/asymmetric/utils/#cryptography.hazmat.primitives.asymmetric.utils.Prehashed

Tests aren't passing yet, still need to dig in. 

Previous logic was using https://github.com/samstav/cryptography/commit/fe0f0486dfa52bc4916c619c42270400dc6a54c6

My first go went like this:

```python
        signature = self.private_key.sign(
            data,
            padding.PKCS1v15(),
            utils.Prehashed(hashes.SHA1())
        )
```

but we get this:


```
Traceback (most recent call last):
  File "~/requests-chef/requests_chef/mixlib_auth.py", line 110, in __call__
    signed = self.private_key.sign(canonical_request, b64=True)
  File "~/requests-chef/requests_chef/mixlib_auth.py", line 191, in sign
    utils.Prehashed(hashes.SHA1())
  File "~/.virtualenvs/requests-chef-dev/lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/rsa.py", line 459, in sign
    self._backend, data, algorithm
  File "~/.virtualenvs/requests-chef-dev/lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/utils.py", line 42, in _calculate_digest_and_algorithm
    "The provided data must be the same length as the hash "
ValueError: The provided data must be the same length as the hash algorithm's digest size.
```

So I changed to:

```python
        signature = self.private_key.sign(
            hashlib.sha1(data).digest(),
            padding.PKCS1v15(),
            utils.Prehashed(hashes.SHA1())
        )
```

but the tests fail, and I assume requests to a chef server would also fail. 